### PR TITLE
add kover library for koverage and PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI with Kover
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  run-tests:
+    name: Execute Tests & Generate Coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x gradlew
+
+      - name: Run tests & enforce coverage
+        run: ./gradlew clean check
+
+      - name: Generate XML coverage report
+        run: ./gradlew koverXmlReport
+
+      - name: Upload coverage report artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: kover-coverage-report
+          path: build/reports/kover/
+          retention-days: 1
+
+  analyze-pr:
+    name: Comment Coverage Summary
+    needs: run-tests
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: kover-coverage-report
+          path: build/reports/kover/
+
+      - name: Comment on PR with coverage
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: build/reports/kover/xml/report.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 80
+          min-coverage-changed-files: 80
+          update-comment: true
+          title: Code Coverage Summary
+          pass-emoji: '✅'
+          fail-emoji: '❌'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("jvm") version "2.1.10"
+    id("org.jetbrains.kotlinx.kover") version "0.9.1"
 }
 
 group = "com.berlin"
@@ -10,12 +11,50 @@ repositories {
 }
 
 dependencies {
+    implementation("io.insert-koin:koin-core:4.0.4")
+    implementation ("org.jetbrains.kotlinx:kotlinx-datetime:0.6.2")
+
     testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
+    testImplementation("io.mockk:mockk:1.14.0")
+    testImplementation("com.google.truth:truth:1.4.4")
+    testImplementation("org.jetbrains.kotlin:kotlin-test")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "**.model.**",
+                    "**.di.**"
+                )
+            }
+        }
+
+        total {
+            verify {
+                rule {
+                    minBound(80)
+                }
+            }
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+tasks.named("check") {
+    dependsOn(tasks.koverVerify)
 }
 
 tasks.test {
     useJUnitPlatform()
 }
+
 kotlin {
     jvmToolchain(23)
 }

--- a/src/test/kotlin/MainKtTest.kt
+++ b/src/test/kotlin/MainKtTest.kt
@@ -1,0 +1,21 @@
+package com.berlin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class MainTest {
+
+    @Test
+    fun `main prints Hello World`() {
+        val buffer = ByteArrayOutputStream()
+        System.setOut(PrintStream(buffer))
+
+        main()
+
+        val output = buffer.toString().trim()
+        assertThat(output)
+            .isEqualTo("Hello World!")
+    }
+}


### PR DESCRIPTION
Integrate the Kotlin Kover plugin to enforce ≥ 80 % line-coverage (excluding any model/di packages), hook koverVerify into ./gradlew check, and add a GitHub Actions workflow that runs this check only on pull requests to main or development.